### PR TITLE
Separable filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.dub
+docs.json
+__dummy.html
+*.o
+*.obj
+__test__*__
+dub.selections.json
+libmir-cv.a

--- a/dub.json
+++ b/dub.json
@@ -1,0 +1,34 @@
+{
+    "name": "mir-cv",
+    "authors": [
+        "Relja Ljubobratovic",
+        "Ilya Yaroshenko",
+        "Mir Developers (see information per file)"
+    ],
+    "description": "Low-level (betterC) modules for dcv library.",
+    "copyright": "Copyright © 2017, Relja Ljubobratovic, Ilya Yaroshenko",
+    "license": "BSL-1.0",
+    "dependencies": {
+        "mir-cpuid" : "~>0.4.2",
+        "mir-algorithm": "~>0.5.0"
+    },
+    "buildTypes": {
+        "betterC": {
+            "buildOptions": ["noBoundsCheck", "releaseMode", "optimize", "inline"],
+            "dflags-ldc": ["-betterC", "-mcpu=native", "-enable-cross-module-inlining"]
+        }
+    },
+    "configurations": [
+        {
+            "name": "default"
+        },
+        {
+            "name": "static",
+            "targetType": "staticLibrary"
+        },
+        {
+            "name": "dynamic",
+            "targetType": "dynamicLibrary"
+        }
+    ]
+}

--- a/source/mir/cv/core/memory.d
+++ b/source/mir/cv/core/memory.d
@@ -1,0 +1,152 @@
+/+
+    Module contains memory handing routines used throughout the library.
++/
+module mir.cv.core.memory;
+
+import core.stdc.stdlib : malloc, free;
+
+version (Posix)
+@nogc nothrow
+private extern(C) int posix_memalign(void**, size_t, size_t);
+
+// Copy pasta of aligned memory allocation used in std.experimental.allocation.mallocator.AlignedMallocator ////////////
+
+version (Windows)
+{
+    // DMD Win 32 bit, DigitalMars C standard library misses the _aligned_xxx
+    // functions family (snn.lib)
+    version(CRuntime_DigitalMars)
+    {
+        // Helper to cast the infos written before the aligned pointer
+        // this header keeps track of the size (required to realloc) and of
+        // the base ptr (required to free).
+        private struct AlignInfo
+        {
+            void* basePtr;
+            size_t size;
+
+            @nogc nothrow
+            static AlignInfo* opCall(void* ptr)
+            {
+                return cast(AlignInfo*) (ptr - AlignInfo.sizeof);
+            }
+        }
+
+        @nogc nothrow
+        private void* _aligned_malloc(size_t size, size_t alignment)
+        {
+            import std.c.stdlib: malloc;
+            size_t offset = alignment + size_t.sizeof * 2 - 1;
+
+            // unaligned chunk
+            void* basePtr = malloc(size + offset);
+            if (!basePtr) return null;
+
+            // get aligned location within the chunk
+            void* alignedPtr = cast(void**)((cast(size_t)(basePtr) + offset)
+                & ~(alignment - 1));
+
+            // write the header before the aligned pointer
+            AlignInfo* head = AlignInfo(alignedPtr);
+            head.basePtr = basePtr;
+            head.size = size;
+
+            return alignedPtr;
+        }
+
+        @nogc nothrow
+        private void* _aligned_realloc(void* ptr, size_t size, size_t alignment)
+        {
+            import std.c.stdlib: free;
+            import std.c.string: memcpy;
+
+            if(!ptr) return _aligned_malloc(size, alignment);
+
+            // gets the header from the exising pointer
+            AlignInfo* head = AlignInfo(ptr);
+
+            // gets a new aligned pointer
+            void* alignedPtr = _aligned_malloc(size, alignment);
+            if (!alignedPtr)
+            {
+                //to https://msdn.microsoft.com/en-us/library/ms235462.aspx
+                //see Return value: in this case the original block is unchanged
+                return null;
+            }
+
+            // copy exising data
+            memcpy(alignedPtr, ptr, head.size);
+            free(head.basePtr);
+
+            return alignedPtr;
+        }
+
+        @nogc nothrow
+        private void _aligned_free(void *ptr)
+        {
+            import std.c.stdlib: free;
+            if (!ptr) return;
+            AlignInfo* head = AlignInfo(ptr);
+            free(head.basePtr);
+        }
+
+    }
+    // DMD Win 64 bit, uses microsoft standard C library which implements them
+    else
+    {
+        @nogc nothrow private extern(C) void* _aligned_malloc(size_t, size_t);
+        @nogc nothrow private extern(C) void _aligned_free(void *memblock);
+        @nogc nothrow private extern(C) void* _aligned_realloc(void *, size_t, size_t);
+    }
+}
+
+version(Posix)
+@trusted @nogc nothrow
+void[] alignedAllocate(size_t bytes, uint a)
+{
+    import core.stdc.errno : ENOMEM, EINVAL;
+    void* result;
+    auto code = posix_memalign(&result, a, bytes);
+    if (code == ENOMEM)
+        return null;
+
+    else if (code == EINVAL)
+        assert (0, "AlignedMallocator.alignment is not a power of two multiple of (void*).sizeof, according to posix_memalign!");
+
+    else if (code != 0)
+        assert (0, "posix_memalign returned an unknown code!");
+
+    else
+        return result[0 .. bytes];
+}
+else version(Windows)
+@trusted @nogc nothrow
+void[] alignedAllocate(size_t bytes, uint a)
+{
+    auto result = _aligned_malloc(bytes, a);
+    return result ? result[0 .. bytes] : null;
+}
+else static assert(0);
+
+/**
+Calls $(D free(b.ptr)) on Posix and
+$(WEB msdn.microsoft.com/en-US/library/17b5h8td(v=vs.80).aspx,
+$(D __aligned_free(b.ptr))) on Windows.
+*/
+version (Posix)
+@system @nogc nothrow
+bool deallocate(void[] b)
+{
+    import core.stdc.stdlib : free;
+    free(b.ptr);
+    return true;
+}
+else version (Windows)
+@system @nogc nothrow
+bool deallocate(void[] b)
+{
+    _aligned_free(b.ptr);
+    return true;
+}
+else static assert(0);
+

--- a/source/mir/cv/core/simd.d
+++ b/source/mir/cv/core/simd.d
@@ -1,0 +1,77 @@
+/+
+    Utilities to help use SIMD vectors.
++/
+
+module mir.cv.core.simd;
+
+import cpuid.x86_any;
+import std.traits : isNumeric, TemplateOf;
+
+extern(C) @system nothrow @nogc:
+
+private
+{
+    // TODO: Do we need this?
+    struct Init_cpu_id
+    {
+        static void init()
+        {
+            cpuid_x86_any_init();
+        }
+    }
+    static Init_cpu_id __cpuid_init;
+}
+
+
+/++
+    SIMD instructionset traits.
++/
+mixin template Instruction_set_trait(size_t _bitsize, T)
+{
+    enum bitsize = _bitsize;
+    enum elementCount = (bitsize / 8) / T.sizeof;
+
+    alias Vector = .Vector!(bitsize, T);
+    alias Scalar = T;
+}
+
+/// SSE (128bit) instruction set descriptor.
+template SSE(T)
+if (isNumeric!T)
+{
+    mixin Instruction_set_trait!(128, T);
+}
+
+/// AVX (256bit) instruction set descriptor.
+template AVX(T)
+if (isNumeric!T)
+{
+    mixin Instruction_set_trait!(256, T);
+}
+
+/// Non-simd, instruction set mock-up.
+template Non_SIMD(T)
+if (isNumeric!T)
+{
+    enum bitsize = 8;
+    enum elementCount = 1;
+    alias Vector = T;
+    alias Scalar = T;
+}
+
+template Is_SIMD(alias InstructionSet){
+    static if (__traits(isSame, TemplateOf!InstructionSet, SSE)) {
+        enum Is_SIMD = true;
+    } else static if (__traits(isSame, TemplateOf!InstructionSet, AVX) ) {
+        enum Is_SIMD = true;
+    } else {
+        enum Is_SIMD = false;
+    }
+}
+
+/// SIMD vector trait - build vector type using bitsize and scalar type.
+template Vector(size_t bitsize, T)
+{
+    alias Vector = __vector(T[(bitsize / 8) / T.sizeof]);
+}
+

--- a/source/mir/cv/imgproc/imfilter.d
+++ b/source/mir/cv/imgproc/imfilter.d
@@ -1,0 +1,459 @@
+/++
+    Image filtering routines.
++/
+
+module mir.cv.imgproc.imfilter;
+
+import core.stdc.stdlib;
+
+import mir.ndslice.slice : Slice, Universal, sliced;
+import mir.ndslice.topology : zip, unzip, blocks, universal, map, windows;
+import mir.ndslice.dynamic : strided;
+import mir.ndslice.algorithm : each;
+
+import mir.cv.core.memory;
+import mir.cv.core.simd;
+
+import cpuid.x86_any;
+
+import core.simd;
+import ldc.simd;
+
+
+extern (C) @system nothrow @nogc:
+
+
+// Border handing methods used in image filteirng.
+enum BORDER_REPLICATE = 0;
+enum BORDER_SAME = 1;
+enum BORDER_SYMMETRIC = 2;
+
+// Error codes that can occur in image filtering calls.
+enum ERROR_INVALID_BORDER_METHOD = 1;
+
+/++
+    Separable image filtering.
+
+    Params:
+        inputbuf        = Input image. Size of 'rows' * 'cols'.
+        hmask           = Horizontal mask. Size of 'hsize'.
+        vmask           = Vertical mask. Size of 'vsize'.
+        outputbuf       = Output image. Size of 'rows' * 'cols'.
+        rows            = Row size (height) of input/output images.
+        cols            = Column size (width) of input/output images.
+        hsize           = Size of horizontal kernel.
+        vsize           = Size of vertical kernel.
+        border_handling = Border handling scheme used to process borders of the image.
+
+    Returns:
+        0 if successful, ERROR_INVALID_BORDER_METHOD if invalid value is passed for border_handling parameter.
++/
+pragma(inline, false)
+int separable_imfilter
+(
+    float* inputbuf,
+    float* hmask,
+    float* vmask,
+    float* outputbuf,
+    size_t rows,
+    size_t cols,
+    size_t hsize,
+    size_t vsize,
+    int border_handling = BORDER_REPLICATE
+)
+{
+    return separable_imfilter_impl
+        (inputbuf, hmask, vmask, outputbuf, rows, cols, hsize, vsize, border_handling);
+}
+
+package(mir.cv):
+
+template Horizontal_kernel_func(alias InstructionSet)
+{
+    alias Horizontal_kernel_func = void function(InstructionSet.Scalar*, // input pointer.
+        InstructionSet.Vector*, // kernel mask pointer.
+        InstructionSet.Scalar*, // output pointer.
+        size_t); // size of the kernel mask.
+}
+
+template Vertical_kernel_func(alias InstructionSet)
+{
+    alias Vertical_kernel_func = void function(InstructionSet.Scalar*, // input pointer.
+        InstructionSet.Vector*, // kernel mask pointer.
+        InstructionSet.Scalar*, // output pointer.
+        size_t, // size of the kernel mask.
+        size_t); // rowstride to read another row element.
+}
+
+pragma(inline, true)
+auto max(T)(T t1, T t2) {
+    return (t1 > t2) ? t1 : t2;
+}
+
+int separable_imfilter_impl(T)
+(
+    T* inputbuf,
+    T* hmask,
+    T* vmask,
+    T* outputbuf,
+    size_t rows,
+    size_t cols,
+    size_t hsize,
+    size_t vsize,
+    int border_handling = BORDER_REPLICATE
+)
+{
+    auto tempbuf = cast(T[])alignedAllocate(rows * cols * T.sizeof, 16); // temporary buffer, used to store horizontal filtering
+
+    scope (exit)
+    {
+        deallocate(tempbuf);
+    }
+
+    auto input = inputbuf.sliced(rows, cols).universal;
+    auto temp = tempbuf.sliced(rows, cols).universal;
+    auto output = outputbuf.sliced(rows, cols).universal;
+    auto hm = hmask.sliced(hsize).universal;
+    auto vm = vmask.sliced(vsize).universal;
+
+    if (avx) // add version (compile time flag if avx should be supported)
+    {
+        inner_filtering_impl!(AVX!T)(input, temp, hm, vm, output,
+            &apply_horizontal_kernel_simd!(AVX!T), &apply_vertical_kernel_simd!(AVX!T));
+    }
+    else version (sse)
+    {
+        inner_filtering_impl!(SSE!T)(input, temp, hm, vm, output,
+            &apply_horizontal_kernel_simd!(SSE!T), &apply_vertical_kernel_simd!(SSE!T));
+    }
+    else
+    {
+        inner_filtering_impl!(Non_SIMD!T)(input, temp, hm, vm, output,
+            get_horizontal_kernel_for_mask!T(hsize), get_vertical_kernel_for_mask!T(vsize));
+    }
+
+    if (border_handling != BORDER_REPLICATE)
+    {
+        return ERROR_INVALID_BORDER_METHOD;
+    }
+
+    borders_replicate_impl(output, hsize, vsize);
+
+    return 0;
+}
+
+pragma(inline, true) void inner_filtering_impl(alias InstructionSet)(
+    Slice!(Universal, [2], InstructionSet.Scalar*) input, Slice!(Universal,
+    [2], InstructionSet.Scalar*) temp, Slice!(Universal, [1],
+    InstructionSet.Scalar*) hmask, Slice!(Universal, [1],
+    InstructionSet.Scalar*) vmask, Slice!(Universal, [2],
+    InstructionSet.Scalar*) output,
+    Horizontal_kernel_func!InstructionSet hkernel, Vertical_kernel_func!InstructionSet vkernel,
+    )
+in
+{
+    assert(input.shape == temp.shape, "Incompatible input and temporary buffer slice");
+    assert(temp.shape == output.shape, "Incompatible input and output buffer slice");
+}
+body
+{
+
+    alias T = InstructionSet.Scalar;
+    alias V = InstructionSet.Vector;
+    immutable velems = InstructionSet.elementCount;
+    immutable tbytes = T.sizeof;
+    immutable vbytes = V.sizeof;
+    immutable hsize = hmask.length;
+    immutable vsize = vmask.length;
+    immutable rows = input.length!0;
+    immutable cols = input.length!1;
+
+    static if (Is_SIMD!InstructionSet)
+    {
+        // It this is SIMD instructions set, allocate vectors for kernels
+
+        auto hk = cast(V[])alignedAllocate(hsize * vbytes, 16); // horizontal simd kernel
+        auto vk = cast(V[])alignedAllocate(vsize * vbytes, 16); // vertical simd kernel
+
+        scope (exit)
+        {
+            deallocate(hk);
+            deallocate(vk);
+        }
+
+        foreach (i; 0 .. hsize)
+        {
+            hk[i].array[] = hmask[i];
+        }
+
+        foreach (i; 0 .. vsize)
+        {
+            vk[i].array[] = vmask[i];
+        }
+    }
+    else
+    {
+        // ... otherwise just use input buffers.
+        auto hk = hmask._iterator[0 .. hsize];
+        auto vk = vmask._iterator[0 .. vsize];
+    }
+
+    // Get pointers to where vectors are loaded (has to be public)
+    static auto toPtr(ref T e)
+    {
+        return &e;
+    }
+
+    // Stride buffers to match vector indexing.
+    auto a = input[0 .. $ - vsize, 0 .. $ - hsize].strided!1(velems).map!toPtr;
+    auto t = temp[0 .. $ - vsize, 0 .. $ - hsize].strided!1(velems).map!toPtr;
+    auto b = output[0 .. $ - vsize, 0 .. $ - hsize].strided!1(velems).map!toPtr;
+
+    // L1 cache block tiling (under 8192 bytes)
+    immutable rtiling = 32;
+    immutable ctiling = max(1, 256 / (tbytes * hsize));
+
+    // Process blocks
+    zip!true(a, t, b)
+    .blocks(rtiling, ctiling)
+  //.parallel
+    .each!((b) {
+        b.each!((w) { hkernel(w.a, hk.ptr, w.b, hsize); }); // apply horizontal kernel
+            b.each!((w) { vkernel(w.b, vk.ptr, w.c, vsize, cols); }); // apply vertical kernel
+    });
+
+    // Fill-in block horizontal borders
+    zip!true(t, b)[rtiling - vsize .. $ - vsize, 0 .. $]
+    .windows(vsize, b.length!1)
+    .strided!0(rtiling)
+    .each!((b) {
+        b.each!((w) { vkernel(w.a, vk.ptr, w.b, vsize, cols); });
+    });
+
+    // perform scalar processing for the remaining pixels (from vector block selection)
+    immutable rrb = a.length!0 - (a.length!0 % rtiling) - vsize;
+    immutable crb = (a.length!1 - (a.length!1 % ctiling)) * velems - hsize;
+    immutable rowstride = input._strides[0];
+
+    // get scalar kernels
+    auto hskernel = get_horizontal_kernel_for_mask!T(hsize);
+    auto vskernel = get_vertical_kernel_for_mask!T(vsize);
+
+    // bottom rows
+    if (rrb < rows - vsize)
+    {
+        a = input[rrb .. $, 0 .. $].map!toPtr;
+        t = temp[rrb .. $, 0 .. $].map!toPtr;
+        b = output[rrb .. $, 0 .. $].map!toPtr;
+
+        zip!true(a, t)[0 .. $, 0 .. $ - hsize].each!((w) { hskernel(w.a, hmask._iterator, w.b, hsize); });
+        zip!true(t, b)[0 .. $ - vsize, 0 .. $ - hsize / 2].each!((w) { vskernel(w.a, vmask._iterator, w.b, vsize, rowstride); });
+    }
+
+    // right columns
+    if (crb < cols - vsize)
+    {
+        a = input[0 .. $, crb .. $].map!toPtr;
+        t = temp[0 .. $, crb .. $].map!toPtr;
+        b = output[0 .. $, crb .. $].map!toPtr;
+
+        zip!true(a, t)[0 .. $ - vsize, 0 .. $ - hsize].each!((w) { hskernel(w.a, hmask._iterator, w.b, hsize); });
+        zip!true(t, b)[0 .. $ - vsize, 0 .. $ - hsize / 2].each!((w) { vskernel(w.a, vmask._iterator, w.b, vsize, rowstride); });
+    }
+}
+
+pragma(inline, true) void borders_replicate_impl(T)
+(
+    Slice!(Universal, [2], T*) output,
+    size_t hsize,
+    size_t vsize
+)
+{
+    auto top = output[0 .. vsize / 2 + 1, hsize / 2 .. $ - hsize / 2 + 1];
+    auto bottom = output[$ - vsize / 2 - 2 .. $, hsize / 2 .. $ - hsize / 2 + 1];
+
+    foreach (c; 0 .. top.length!1)
+    {
+        foreach (r; 0 .. top.length!0 - 1)
+        {
+            top[r, c] = top[hsize / 2 + 1, c];
+            bottom[r + 1, c] = bottom[0, c];
+        }
+    }
+
+    auto left = output[0 .. $, 0 .. hsize / 2 + 1];
+    auto right = output[0 .. $, $ - hsize / 2 - 2 .. $];
+
+    foreach (r; 0 .. left.length!0)
+    {
+        foreach (c; 0 .. left.length!1 - 1)
+        {
+            left[r, c] = left[r, hsize / 2 + 1];
+            right[r, c + 1] = right[r, 0];
+        }
+    }
+}
+// Horizontal kernels //////////////////////////////////////////////////////////
+
+pragma(inline, true)
+void apply_horizontal_kernel_3(T)(T* i, T* k, T* o, size_t)
+{
+    o[1] = cast(T)(i[0] * k[0] +
+                   i[1] * k[1] +
+                   i[2] * k[2]);
+}
+
+pragma(inline, true)
+void apply_horizontal_kernel_5(T)(T* i, T* k, T* o, size_t)
+{
+    o[2] =
+        cast(T)(i[0] * k[0] +
+                i[1] * k[1] +
+                i[2] * k[2] +
+                i[3] * k[3] +
+                i[4] * k[4]);
+}
+
+pragma(inline, true)
+void apply_horizontal_kernel_7(T)(T* i, T* k, T* o, size_t)
+{
+    o[3] =
+        cast(T)(i[0] * k[0] +
+                i[1] * k[1] +
+                i[2] * k[2] +
+                i[3] * k[3] +
+                i[4] * k[4] +
+                i[5] * k[5] +
+                i[6] * k[6]);
+}
+
+pragma(inline, true)
+void apply_horizontal_kernel(T)(T* i, T* k, T* o, size_t msize)
+{
+    T r = T(0);
+    foreach (_; 0 .. msize)
+    {
+        r += (*(i++)) * (*(k++));
+    }
+    o[msize / 2] = r;
+}
+
+// Vertical kernels ////////////////////////////////////////////////////////////
+
+pragma(inline, true)
+void apply_vertical_kernel_3(T)(T* i, T* k, T* o, size_t, size_t rowstride)
+{
+    o[rowstride] =
+        cast(T)(i[0] * k[0] +
+                i[rowstride] * k[1] +
+                i[rowstride * 2] * k[2]);
+}
+
+pragma(inline, true)
+void apply_vertical_kernel_5(T)(T* i, T* k, T* o, size_t, size_t rowstride)
+{
+    o[rowstride * 2] =
+        cast(T)(i[0] * k[0] +
+                i[rowstride] * k[1] +
+                i[rowstride * 2] * k[2] +
+                i[rowstride * 3] * k[3] +
+                i[rowstride * 4] * k[4]);
+}
+
+pragma(inline, true)
+void apply_vertical_kernel_7(T)(T* i, T* k, T* o, size_t, size_t rowstride)
+{
+    o[rowstride * 3] =
+        cast(T)(i[0] * k[0] +
+                i[rowstride] * k[1] +
+                i[rowstride * 2] * k[2] +
+                i[rowstride * 3] * k[3] +
+                i[rowstride * 4] * k[4] +
+                i[rowstride * 5] * k[5] +
+                i[rowstride * 6] * k[6]);
+}
+
+pragma(inline, true)
+void apply_vertical_kernel(T)(T* i, T* k, T* o, size_t msize,
+    size_t rowstride)
+{
+    T r = T(0);
+    foreach (_; 0 .. msize)
+    {
+        r += (*i) * (*(k++));
+        i += rowstride;
+    }
+    o[rowstride * (msize / 2)] = r;
+}
+
+// SIMD kernels ////////////////////////////////////////////////////////////////
+
+pragma(inline, true)
+void apply_horizontal_kernel_simd(alias InstructionSet)(
+    InstructionSet.Scalar* i, InstructionSet.Vector* k, InstructionSet.Scalar* o, size_t ksize)
+{
+    alias V = InstructionSet.Vector;
+    V e = InstructionSet.Scalar(0);
+    foreach (_; 0 .. ksize)
+    {
+        e += loadUnaligned!V(i++) * (*(k++));
+    }
+    storeUnaligned!V(e, o + ksize / 2);
+}
+
+pragma(inline, true)
+void apply_vertical_kernel_simd(alias InstructionSet)
+(
+    InstructionSet.Scalar* i,
+    InstructionSet.Vector* k,
+    InstructionSet.Scalar* o,
+    size_t ksize,
+    size_t rowstride
+)
+{
+    alias V = InstructionSet.Vector;
+    V e = InstructionSet.Scalar(0);
+    foreach (_; 0 .. ksize)
+    {
+        e += loadUnaligned!V(i) * (*(k++));
+        i += rowstride;
+    }
+    storeUnaligned!V(e, o + (ksize / 2) * rowstride);
+}
+
+// Scalar kernel getters ///////////////////////////////////////////////////////
+
+pragma(inline, true)
+auto get_horizontal_kernel_for_mask(T)(size_t mask_size)
+{
+    switch (mask_size)
+    {
+    case 3:
+        return &apply_horizontal_kernel_3!T;
+    case 5:
+        return &apply_horizontal_kernel_5!T;
+    case 7:
+        return &apply_horizontal_kernel_7!T;
+    default:
+        break;
+    }
+    return &apply_horizontal_kernel!T;
+}
+
+pragma(inline, true)
+auto get_vertical_kernel_for_mask(T)(size_t mask_size)
+{
+    switch (mask_size)
+    {
+    case 3:
+        return &apply_vertical_kernel_3!T;
+    case 5:
+        return &apply_vertical_kernel_5!T;
+    case 7:
+        return &apply_vertical_kernel_7!T;
+    default:
+        break;
+    }
+    return &apply_vertical_kernel!T;
+}
+

--- a/source/mir/cv/imgproc/imfilter.d
+++ b/source/mir/cv/imgproc/imfilter.d
@@ -175,7 +175,7 @@ in
 }
 body
 {
-    import mir.ndslice.topology : flattened;
+    import mir.ndslice.topology : flattened, iota;
 
     alias T = InstructionSet.Scalar;
     alias V = InstructionSet.Vector;
@@ -183,6 +183,7 @@ body
     immutable tbytes = T.sizeof;
     immutable vbytes = V.sizeof;
     immutable ksize = hmask.length;
+    immutable shape = input.shape;
     immutable rows = input.length!0;
     immutable cols = input.length!1;
 
@@ -216,15 +217,9 @@ body
         auto vk = vmask._iterator[0 .. ksize];
     }
 
-    // Get pointers to where vectors are loaded (has to be public)
-    static auto toPtr(ref T e)
-    {
-        return &e;
-    }
-
-    auto _in = input.universal.map!toPtr;
-    auto _tmp = temp.universal.map!toPtr;
-    auto _out = output.universal.map!toPtr;
+    auto _in = iota(shape, input._iterator).universal;
+    auto _tmp = iota(shape, temp._iterator).universal;
+    auto _out = iota(shape, output._iterator).universal;
 
     // Stride buffers to match vector indexing.
     auto a = _in[0 .. $ - ksize, 0 .. $ - ksize].strided!1(velems);

--- a/source/mir/cv/imgproc/imfilter.d
+++ b/source/mir/cv/imgproc/imfilter.d
@@ -139,14 +139,17 @@ int separable_imfilter_impl(T)
     return 0;
 }
 
-pragma(inline, true) void inner_filtering_impl(alias InstructionSet)(
-    Slice!(Universal, [2], InstructionSet.Scalar*) input, Slice!(Universal,
-    [2], InstructionSet.Scalar*) temp, Slice!(Universal, [1],
-    InstructionSet.Scalar*) hmask, Slice!(Universal, [1],
-    InstructionSet.Scalar*) vmask, Slice!(Universal, [2],
-    InstructionSet.Scalar*) output,
-    Horizontal_kernel_func!InstructionSet hkernel, Vertical_kernel_func!InstructionSet vkernel,
-    )
+pragma(inline, true)
+void inner_filtering_impl(alias InstructionSet)
+(
+    Slice!(Universal, [2], InstructionSet.Scalar*) input,
+    Slice!(Universal, [2], InstructionSet.Scalar*) temp,
+    Slice!(Universal, [1], InstructionSet.Scalar*) hmask,
+    Slice!(Universal, [1], InstructionSet.Scalar*) vmask,
+    Slice!(Universal, [2], InstructionSet.Scalar*) output,
+    Horizontal_kernel_func!InstructionSet hkernel,
+    Vertical_kernel_func!InstructionSet vkernel,
+)
 in
 {
     assert(input.shape == temp.shape, "Incompatible input and temporary buffer slice");
@@ -154,7 +157,6 @@ in
 }
 body
 {
-
     alias T = InstructionSet.Scalar;
     alias V = InstructionSet.Vector;
     immutable velems = InstructionSet.elementCount;
@@ -259,7 +261,8 @@ body
     }
 }
 
-pragma(inline, true) void borders_replicate_impl(T)
+pragma(inline, true)
+void borders_replicate_impl(T)
 (
     Slice!(Universal, [2], T*) output,
     size_t hsize,
@@ -386,8 +389,13 @@ void apply_vertical_kernel(T)(T* i, T* k, T* o, size_t msize,
 // SIMD kernels ////////////////////////////////////////////////////////////////
 
 pragma(inline, true)
-void apply_horizontal_kernel_simd(alias InstructionSet)(
-    InstructionSet.Scalar* i, InstructionSet.Vector* k, InstructionSet.Scalar* o, size_t ksize)
+void apply_horizontal_kernel_simd(alias InstructionSet)
+(
+    InstructionSet.Scalar* i,
+    InstructionSet.Vector* k,
+    InstructionSet.Scalar* o,
+    size_t ksize
+)
 {
     alias V = InstructionSet.Vector;
     V e = InstructionSet.Scalar(0);

--- a/source/mir/cv/imgproc/imfilter.d
+++ b/source/mir/cv/imgproc/imfilter.d
@@ -7,6 +7,7 @@ module mir.cv.imgproc.imfilter;
 import core.stdc.stdlib;
 
 import mir.utility : max;
+import mir.internal.utility : fastmath;
 
 import mir.ndslice.slice : Slice, Contiguous, sliced;
 import mir.ndslice.topology : zip, unzip, blocks, universal, map, windows;
@@ -22,7 +23,7 @@ import core.simd;
 import ldc.simd;
 
 
-extern (C) @system nothrow @nogc:
+extern (C) @system nothrow @nogc @fastmath:
 
 
 // Border handing methods used in image filteirng.

--- a/source/mir/cv/imgproc/imfilter.d
+++ b/source/mir/cv/imgproc/imfilter.d
@@ -6,6 +6,8 @@ module mir.cv.imgproc.imfilter;
 
 import core.stdc.stdlib;
 
+import mir.utility : max;
+
 import mir.ndslice.slice : Slice, Universal, sliced;
 import mir.ndslice.topology : zip, unzip, blocks, universal, map, windows;
 import mir.ndslice.dynamic : strided;
@@ -83,11 +85,6 @@ template Vertical_kernel_func(alias InstructionSet)
         InstructionSet.Scalar*, // output pointer.
         size_t, // size of the kernel mask.
         size_t); // rowstride to read another row element.
-}
-
-pragma(inline, true)
-auto max(T)(T t1, T t2) {
-    return (t1 > t2) ? t1 : t2;
 }
 
 int separable_imfilter_impl(T)
@@ -456,4 +453,3 @@ auto get_vertical_kernel_for_mask(T)(size_t mask_size)
     }
     return &apply_vertical_kernel!T;
 }
-


### PR DESCRIPTION
Hey @9il!

Just after we opened mir-cv, next semester started, and I got caught up in an academic meat grinder again. So sorry for the delay.

Anyhow, I wanted to take a shot at separable filtering as my first mir-cv addition. I was hopping you'd take a look at what I've done so far. I think this meets betterC standards (once compiled with betterC flag and linked to another executable, [`separable_imfilter`](https://github.com/libmir/mir-cv/blob/imfilter/source/mir/cv/imgproc/imfilter.d#L52) function works as expected).

I've  started a PR right away to have dedicated chat space, and hopefully this makes change tracking easier for you. Hopefully that's ok with you.

## Design

I've tried building a filtering framework on which many other filtering algorithms (hopefully) could rely on. Having kernels as function pointers with the form I believe would be flexible enough to support many other filtering algorithms (sobel, bilateral, median etc.) - not really sure current design allows this, but nevertheless- that is the goal.

## Implementation

Please note that I'm aware this looks more like the 'realC', rather than a 'betterC', but I'm hopping you'll point me where this can be improved. Regardless, I've implemented basic SIMD support, which shows nice results with AVX and single precision floating vectors on my machine. I've also tried making code [cache friendly](https://github.com/libmir/mir-cv/blob/imfilter/source/mir/cv/imgproc/imfilter.d#L212-L223) - I'm not sure how'd I test cache missing, but this scheme sure is faster than naive variant, so I'm hopeful I've done it right.

## Results

On 512x512x1 test image, here are some rough results (I'll make a real profiling once I'm done with implementation):

- 3x3 filtering takes ~400 microsecs (dcv's `conv` takes about 4 ms even though is parallelized, where [`separable_imfilter` is not](https://github.com/libmir/mir-cv/blob/imfilter/source/mir/cv/imgproc/imfilter.d#L219))
- 5x5 kernel ~600usecs (dcv ~8ms)
- 7x7 ~800usecs (cv ~20ms)
- 15x15 ~1300usecs, and so on (haven't tested dcv, but I'd say it's as slow as previous ones).

Note: these results are with inlined (template) calls (without linking). I failed setting up a link time optimization with LDC, without which each 3x3 filtering takes about 1-2ms. Is this expected, and should LTO fix this?

## To be done

- [ ] border handing (so far only replication is done)
- [ ] test filtering framework with other algorithms (sobel, and other filtering algorithms where specialized kernel can be made, bilateral, median etc.)
- [ ] one way filtering (not separated)
- [ ] making C headers, testing with linking against C program
- [ ] there'll be more surely...

Feel free to change anything - just please let me know why the change so I can follow. :)